### PR TITLE
Add drb and syslog to runtime dependencies

### DIFF
--- a/resurrected_god.gemspec
+++ b/resurrected_god.gemspec
@@ -29,4 +29,7 @@ Gem::Specification.new do |s|
   s.extensions = %w[ext/god/extconf.rb]
 
   s.files = Dir['History.md', 'LICENSE', 'README.md', 'bin/**/*', 'ext/**/*', 'lib/**/*']
+
+  s.add_dependency('drb')
+  s.add_dependency('syslog')
 end

--- a/resurrected_god.gemspec
+++ b/resurrected_god.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |s|
 
   s.files = Dir['History.md', 'LICENSE', 'README.md', 'bin/**/*', 'ext/**/*', 'lib/**/*']
 
-  s.add_dependency('drb')
-  s.add_dependency('syslog')
+  s.add_dependency('drb', '~> 2.0')
+  s.add_dependency('syslog', '~> 0.1')
 end


### PR DESCRIPTION
They will be the bundled gems in the future version of Ruby.

https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/

> Standard library updates
> RubyGems and Bundler warn if users do require the following gems without adding them to Gemfile or gemspec. This is because they will become the bundled gems in the future version of Ruby.