### PR TITLE
Fix compilation of extension on GCC 15

### DIFF
--- a/ext/god/kqueue_handler.c
+++ b/ext/god/kqueue_handler.c
@@ -63,8 +63,9 @@ kqh_monitor_process(VALUE klass, VALUE pid, VALUE mask)
 }
 
 VALUE
-kqh_handle_events()
+kqh_handle_events(VALUE klass)
 {
+  (void)klass;
   int nevents, i, num_to_fetch;
   struct kevent *events;
 

--- a/ext/god/netlink_handler.c
+++ b/ext/god/netlink_handler.c
@@ -29,8 +29,9 @@ static int nl_sock;   /* socket for netlink connection  */
 
 
 VALUE
-nlh_handle_events()
+nlh_handle_events(VALUE klass)
 {
+  (void)klass;
   char buff[CONNECTOR_MAX_MSG_SIZE];
   struct nlmsghdr *hdr;
   struct proc_event *event;


### PR DESCRIPTION
GCC 15 switched the default C standard to gnu23 in which no parameter is treated as `(void)` which is not matching the signature of `VALUE(*)(VALUE)` that `rb_define_singleton_method` expects.

```
current directory: /var/lib/gems/3.3.0/gems/resurrected_god-1.1.1/ext/god
/usr/bin/ruby3.3 -I/usr/lib/ruby/vendor_ruby extconf.rb
checking for rb_wait_for_single_fd()... yes
checking for linux/netlink.h... yes
checking for linux/connector.h... yes
checking for linux/cn_proc.h... yes
creating Makefile

current directory: /var/lib/gems/3.3.0/gems/resurrected_god-1.1.1/ext/god
make DESTDIR\= sitearchdir\=./.gem.20260325-4172-d4rv0u sitelibdir\=./.gem.20260325-4172-d4rv0u clean

current directory: /var/lib/gems/3.3.0/gems/resurrected_god-1.1.1/ext/god
make DESTDIR\= sitearchdir\=./.gem.20260325-4172-d4rv0u sitelibdir\=./.gem.20260325-4172-d4rv0u
compiling kqueue_handler.c
compiling netlink_handler.c
In file included from /usr/include/ruby-3.3.0/ruby/ruby.h:27,
                 from /usr/include/ruby-3.3.0/ruby.h:38,
                 from netlink_handler.c:3:
netlink_handler.c: In function 'Init_netlink_handler_ext':
/usr/include/ruby-3.3.0/ruby/internal/anyargs.h:308:143: error: passing argument 3 of 'rb_define_singleton_method_00' from incompatible pointer type [-Wincompatible-pointer-types]
  308 | #define rb_define_singleton_method(obj, mid, func, arity)   RBIMPL_ANYARGS_DISPATCH_rb_define_singleton_method((arity), (func))((obj), (mid), (func), (arity))
      |                                                                                                                                               ^~~~~~
      |                                                                                                                                               |
      |                                                                                                                                               VALUE (*)(void) {aka long unsigned int (*)(void)}
netlink_handler.c:177:3: note: in expansion of macro 'rb_define_singleton_method'
  177 |   rb_define_singleton_method(cNetlinkHandler, "handle_events", nlh_handle_events, 0);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/ruby-3.3.0/ruby/internal/anyargs.h:271:21: note: expected 'VALUE (*)(VALUE)' {aka 'long unsigned int (*)(long unsigned int)'} but argument is of type 'VALUE (*)(void)' {aka 'long unsigned int (*)(void)'}
  271 | RBIMPL_ANYARGS_DECL(rb_define_singleton_method, VALUE, const char *)
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/ruby-3.3.0/ruby/internal/anyargs.h:255:41: note: in definition of macro 'RBIMPL_ANYARGS_DECL'
  255 | RBIMPL_ANYARGS_ATTRSET(sym) static void sym ## _00(__VA_ARGS__, VALUE(*)(VALUE), int); \
      |                                         ^~~
netlink_handler.c:32:1: note: 'nlh_handle_events' declared here
   32 | nlh_handle_events()
      | ^~~~~~~~~~~~~~~~~
make: *** [Makefile:248: netlink_handler.o] Error 1

make failed, exit code 2

Gem files will remain installed in /var/lib/gems/3.3.0/gems/resurrected_god-1.1.1 for inspection.
Results logged to /var/lib/gems/3.3.0/extensions/x86_64-linux-gnu/3.3.0/resurrected_god-1.1.1/gem_make.out
```

```
root@0bd3a97d734f:/app# gcc --version
gcc (Ubuntu 15.2.0-15ubuntu1) 15.2.0
Copyright (C) 2025 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```